### PR TITLE
Improved foreach support.

### DIFF
--- a/jscala/src/main/scala/org/jscala/JavascriptPrinter.scala
+++ b/jscala/src/main/scala/org/jscala/JavascriptPrinter.scala
@@ -3,7 +3,7 @@ package org.jscala
 object JavascriptPrinter {
   private[this] val substitutions = Map("\\\"".r -> "\\\\\"", "\\n".r -> "\\\\n", "\\r".r -> "\\\\r", "\\t".r -> "\\\\t")
   private[this] def simplify(ast: JsAst): JsAst = ast match {
-    case JsBlock(stmts) => JsBlock(stmts.filter(_ != JsExprStmt(JsUnit)))
+    case JsBlock(stmts) => JsBlock(stmts.filter(_ != JsUnit))
     case JsCase(const, JsBlock(List(stmt))) => JsCase(const, stmt)
     case JsDefault(JsBlock(List(stmt))) => JsDefault(stmt)
     case t => t
@@ -49,9 +49,8 @@ object JavascriptPrinter {
       case JsCall(callee, params)               => s"""${p(callee)}(${params.map(p(_)).mkString(", ")})"""
       case JsBlock(Nil)                         => "{}"
       case JsBlock(stmts)                       => !< + stmts.map(p2(_) + ";\n").mkString + ind() + "}"
-      case JsExprStmt(jsExpr)                   => p(jsExpr)
       case JsTernary(cond, thenp, elsep)        => s"${s(cond)} ? ${p(thenp)} : ${p(elsep)}"
-      case JsIf(cond, JsExprStmt(expr), Some(JsExprStmt(els))) => s"${s(cond)} ? ${p(expr)} : ${p(els)}"
+      case JsIf(cond, expr: JsExpr, Some(els: JsExpr)) => s"${s(cond)} ? ${p(expr)} : ${p(els)}"
       case JsIf(cond, thenp, elsep)             => s"if (${p(cond)}) ${p(thenp)}" + elsep.map(e => s" else ${p(e)}").getOrElse("")
       case JsSwitch(expr, cases, default)       =>  s"switch (${p(expr)}) " +
         !< + cases.map(p2).mkString("\n") + default.map(d => "\n" + p2(d)).getOrElse("") + !>

--- a/jscala/src/main/scala/org/jscala/model.scala
+++ b/jscala/src/main/scala/org/jscala/model.scala
@@ -15,20 +15,13 @@ sealed trait JsStmt extends JsAst {
     case (JsBlock(lhs), JsStmts(rhs)) => JsBlock(lhs ::: rhs)
     case (JsStmts(lhs), JsStmts(rhs)) => JsStmts(lhs ::: rhs)
     case (JsBlock(lhs), s: JsStmt) => JsBlock(lhs :+ s)
-    case (JsBlock(lhs), s: JsExpr) => JsBlock(lhs :+ s.stmt)
     case (s: JsStmt, JsBlock(rhs)) => JsBlock(s :: rhs)
     case (JsStmts(lhs), s: JsStmt) => JsStmts(lhs :+ s)
-    case (JsStmts(lhs), s: JsExpr) => JsStmts(lhs :+ s.stmt)
     case (s: JsStmt, JsStmts(rhs)) => JsStmts(s :: rhs)
     case (lhs: JsStmt, rhs: JsStmt) => JsBlock(List(lhs, rhs))
-    case (lhs: JsStmt, rhs: JsExpr) => JsBlock(List(lhs, rhs.stmt))
   }
 }
-sealed trait JsExpr extends JsAst {
-  def stmt = JsExprStmt(this)
-  def block = JsBlock(List(this.stmt))
-  def join(a: JsAst) = stmt.join(a)
-}
+sealed trait JsExpr extends JsStmt
 sealed trait JsLit extends JsExpr
 
 case class JsBool(value: Boolean) extends JsLit
@@ -55,7 +48,6 @@ case class JsTernary(cond: JsExpr, `then`: JsExpr, `else`: JsExpr) extends JsExp
 case class JsBlock(stmts: List[JsStmt]) extends JsStmt
 case class JsTry(body: JsStmt, cat: Option[JsCatch], fin: Option[JsStmt]) extends JsStmt
 case class JsCatch(ident: JsIdent, body: JsStmt) extends JsStmt
-case class JsExprStmt(jsExpr: JsExpr) extends JsStmt
 case class JsIf(cond: JsExpr, `then`: JsStmt, `else`: Option[JsStmt]) extends JsStmt
 case class JsWhile(cond: JsExpr, body: JsStmt) extends JsStmt
 case class JsFor(init: List[JsStmt], check: JsExpr, update: List[JsStmt], body: JsStmt) extends JsStmt


### PR DESCRIPTION
Improved for statements to better handle arrays and sequences.
For example this is now supported:

``` scala
javascript { Array(1, 2) foreach { i => print(i) } } 
```

and generates following js code:

``` javascript
for (var iColl = [1, 2], iIdx = 0, i = iColl[iIdx]; iIdx < iColl.length; i = iColl[++iIdx]) print(i)
```

Generated for loop has now additional variable to store currently iterated array. 

We can also now iterate over sequences inside other objects, like this:

``` scala
case class User(name: String)
case class Project(title: String, users: Seq[User])

javascript({ (p: Project) =>
  if (p.title == "title")
    for (u <- p.users) print(u.name)
})
```

The most significant change to make this possible was removing of JsExprStmt, we don't really need it, since each expr can be treated as statement. 
And now we don't need to treat expressions in any special way when parsing javascript, jsExpr is just another case inside jsStmt rule, and main rule for jsAst is now:

``` scala
lazy val jsAst: ToExpr[JsAst] = jsStmtOrDie
```

This change was needed because foreach calls were caught in JsCall.
