### PR TITLE
Use fully qualified JScala AST classes to avoid accidentally use importe...

### DIFF
--- a/jscala/src/main/scala/org/jscala/ScalaToJsConverter.scala
+++ b/jscala/src/main/scala/org/jscala/ScalaToJsConverter.scala
@@ -18,20 +18,20 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
     lazy val jsSelect: ToExpr[JsExpr] = {
       // org.scala.package.$ident => $ident
       case Select(Select(Select(Ident(Name("org")), Name("jscala")), Name("package")), Name(name)) =>
-        q"JsIdent($name)"
+        q"org.jscala.JsIdent($name)"
       // org.scala.$ident => $ident
       case Select(Select(Ident(Name("org")), Name("jscala")), Name(name)) =>
-        q"JsIdent($name)"
+        q"org.jscala.JsIdent($name)"
       // objectname.$ident => $ident
       case s@Select(q@Ident(_), name) if q.symbol.isModule => jsExprOrDie(Ident(name))
       case Select(q, name) =>
-        q"JsSelect(${jsExprOrDie(q)}, ${name.decodedName.toString})"
+        q"org.jscala.JsSelect(${jsExprOrDie(q)}, ${name.decodedName.toString})"
     }
 
     lazy val jsUnaryOp: ToExpr[JsUnOp] = {
       case Select(q, n) if encodedUnaryOpsMap.contains(n) =>
         val op = encodedUnaryOpsMap(n)
-        q"JsUnOp($op, ${jsExprOrDie(q)})"
+        q"org.jscala.JsUnOp($op, ${jsExprOrDie(q)})"
     }
 
     def funParams(args: List[Tree]): Tree = {
@@ -52,9 +52,9 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val rhsExpr = jsExprOrDie(rhs)
         // generate correct whole number devision JavaScript if a and b are [Byte,Short,Int,Long]: a/b|0
         if (op == "/" && q.isNum && rhs.isNum)
-          q"""JsBinOp("|", JsBinOp($opExpr, $qExpr, $rhsExpr), JsNum(0, false))"""
-        else q"JsBinOp($opExpr, $qExpr, $rhsExpr)"
-      case Assign(lhs, rhs) =>q"""JsBinOp("=", ${jsExprOrDie(lhs)}, ${jsExprOrDie(rhs)})"""
+          q"""org.jscala.JsBinOp("|", org.jscala.JsBinOp($opExpr, $qExpr, $rhsExpr), org.jscala.JsNum(0, false))"""
+        else q"org.jscala.JsBinOp($opExpr, $qExpr, $rhsExpr)"
+      case Assign(lhs, rhs) =>q"""org.jscala.JsBinOp("=", ${jsExprOrDie(lhs)}, ${jsExprOrDie(rhs)})"""
     }
 
     lazy val jsTupleExpr: PFT[(Tree, Tree)] = {
@@ -69,16 +69,16 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         jsString.applyOrElse(lhs, (t: Tree) => c.abort(arg.pos, "Map key type can only be String")) -> jsExprOrDie(rhs)
       }
       val params = listToExpr(fields.map { case (n, v) => q"($n, $v)" })
-      q"JsAnonObjDecl($params)"
+      q"org.jscala.JsAnonObjDecl($params)"
     }
 
     lazy val jsMapExpr: ToExpr[JsExpr] = {
       case Apply(TypeApply(Select(path, Name("apply")), _), args) if path.tpe.baseClasses.contains(mapFactorySym) =>
         genMap(args)
       case Apply(Select(path, Name("apply")), List(index)) if path.tpe.baseClasses.contains(mapSym) =>
-        q"JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(index)})"
+        q"org.jscala.JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(index)})"
       case Apply(Select(path, Name("update")), List(key, value)) if path.tpe.baseClasses.contains(mapSym) =>
-        q"""JsBinOp("=", JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(key)}), ${jsExprOrDie(value)})"""
+        q"""org.jscala.JsBinOp("=", org.jscala.JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(key)}), ${jsExprOrDie(value)})"""
     }
 
     lazy val jsForStmt: ToExpr[JsStmt] = {
@@ -92,10 +92,10 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val fromExpr = jsExprOrDie(from)
         val init = q"varDef($index, $fromExpr)"
         val check = if (n.decodedName.toString == "until")
-          q"""JsBinOp("<", JsIdent($index), ${jsExprOrDie(endExpr)})"""
-          else q"""JsBinOp("<=", JsIdent($index), ${jsExprOrDie(endExpr)})"""
-        val update = q"""JsUnOp("++", JsIdent($index))"""
-        q"JsFor(List($init), $check, List($update), $forBody)"
+          q"""org.jscala.JsBinOp("<", org.jscala.JsIdent($index), ${jsExprOrDie(endExpr)})"""
+          else q"""org.jscala.JsBinOp("<=", org.jscala.JsIdent($index), ${jsExprOrDie(endExpr)})"""
+        val update = q"""org.jscala.JsUnOp("++", org.jscala.JsIdent($index))"""
+        q"org.jscala.JsFor(List($init), $check, List($update), $forBody)"
       /*
         val coll = Seq(1, 2)
         for (ident <- coll) body
@@ -106,7 +106,7 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         forIn(ident, coll) body
        */
       case app@Apply(Apply(TypeApply(path, _), List(coll)), List(Function(List(ValDef(_, Name(ident), _, _)), body))) if path.is("org.jscala.package.forIn") =>
-        q"JsForIn(JsIdent($ident), ${jsExprOrDie(coll)}, ${jsStmtOrDie(body)})"
+        q"org.jscala.JsForIn(org.jscala.JsIdent($ident), ${jsExprOrDie(coll)}, ${jsStmtOrDie(body)})"
 
       /*
         coll.foreach(item)
@@ -115,24 +115,24 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val collExpr = jsIterableExpr(collTree)
         val coll = s"${ident}Coll"
         val idx = s"${ident}Idx"
-        val seq = q"JsIdent($coll)"
-        val len = q"""JsSelect($seq, "length")"""
-        val init = q"JsVarDef(List($coll -> $collExpr, $idx -> JsNum(0, false), $ident -> JsAccess($seq, JsIdent($idx))))"
-        val check = q"""JsBinOp("<", JsIdent($idx), $len)"""
-        val update = q"""JsBinOp("=", JsIdent($ident), JsAccess(JsIdent($coll), JsUnOp("++", JsIdent($idx))))"""
+        val seq = q"org.jscala.JsIdent($coll)"
+        val len = q"""org.jscala.JsSelect($seq, "length")"""
+        val init = q"org.jscala.JsVarDef(List($coll -> $collExpr, $idx -> org.jscala.JsNum(0, false), $ident -> org.jscala.JsAccess($seq, org.jscala.JsIdent($idx))))"
+        val check = q"""org.jscala.JsBinOp("<", org.jscala.JsIdent($idx), $len)"""
+        val update = q"""org.jscala.JsBinOp("=", org.jscala.JsIdent($ident), org.jscala.JsAccess(org.jscala.JsIdent($coll), org.jscala.JsUnOp("++", org.jscala.JsIdent($idx))))"""
         val forBody = jsStmtOrDie(body)
-        q"JsFor(List($init), $check, List($update), $forBody)"
+        q"org.jscala.JsFor(List($init), $check, List($update), $forBody)"
     }
 
     def forStmt(ident: String, coll: String, body: Tree) = {
       val idx = s"${ident}Idx"
-      val seq = q"JsIdent($coll)"
-      val len = q"""JsSelect($seq, "length")"""
-      val init = q"JsVarDef(List($idx -> JsNum(0, false), $ident -> JsAccess($seq, JsIdent($idx))))"
-      val check = q"""JsBinOp("<", JsIdent($idx), $len)"""
-      val update = q"""JsBinOp("=", JsIdent($ident), JsAccess(JsIdent($coll), JsUnOp("++", JsIdent($idx))))"""
+      val seq = q"org.jscala.JsIdent($coll)"
+      val len = q"""org.jscala.JsSelect($seq, "length")"""
+      val init = q"org.jscala.JsVarDef(List($idx -> org.jscala.JsNum(0, false), $ident -> org.jscala.JsAccess($seq, org.jscala.JsIdent($idx))))"
+      val check = q"""org.jscala.JsBinOp("<", org.jscala.JsIdent($idx), $len)"""
+      val update = q"""org.jscala.JsBinOp("=", org.jscala.JsIdent($ident), org.jscala.JsAccess(org.jscala.JsIdent($coll), org.jscala.JsUnOp("++", org.jscala.JsIdent($idx))))"""
       val forBody = jsStmtOrDie(body)
-      q"JsFor(List($init), $check, List($update), $forBody)"
+      q"org.jscala.JsFor(List($init), $check, List($update), $forBody)"
     }
 
     lazy val jsSeqExpr: ToExpr[JsExpr] = {
@@ -144,46 +144,46 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
     lazy val jsArrayIdentOrExpr: ToExpr[JsExpr] = jsArrayIdent orElse jsArrayExpr
 
     lazy val jsArrayIdent: ToExpr[JsIdent] = {
-      case i @ Ident(name) if i.tpe.baseClasses.contains(arraySym) => q"JsIdent(${name.decodedName.toString})"
+      case i @ Ident(name) if i.tpe.baseClasses.contains(arraySym) => q"org.jscala.JsIdent(${name.decodedName.toString})"
     }
 
     lazy val jsArrayExpr: ToExpr[JsExpr] = {
       // Array creation
       case Apply(TypeApply(path, _), args) if path.is("org.jscala.JArray.apply") =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
       case TypeApply(path, args) if path.is("scala.Array.apply") =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
       case Apply(Apply(TypeApply(path, _), args), _) if path.is("scala.Array.apply") =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
       case TypeApply(path, args) if path.is("scala.Array.apply") =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
       case Apply(path, args) if path.is("scala.Array.apply") =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
       case Apply(Ident(Name("Array")), args) =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
       case Apply(Select(New(AppliedTypeTree(Ident(TypeName("Array")), _)), ctor), List(Literal(Constant(_)))) if ctor == nme.CONSTRUCTOR =>
-        q"JsArray(Nil)"
+        q"org.jscala.JsArray(Nil)"
       // new Array[Int](256)
       case Apply(Select(a@New(t@TypeTree()), ctor), List(Literal(Constant(_))))
         if ctor == nme.CONSTRUCTOR && t.original.isInstanceOf[AppliedTypeTree @unchecked] && t.original.asInstanceOf[AppliedTypeTree].tpt.equalsStructure(Select(Ident(TermName("scala")), TypeName("Array"))) =>
-        q"JsArray(Nil)"
+        q"org.jscala.JsArray(Nil)"
       case Apply(Select(a@New(t@TypeTree()), ctor), List(Literal(Constant(_)))) =>
-        q"JsArray(Nil)"
+        q"org.jscala.JsArray(Nil)"
       case Apply(TypeApply(Select(path, Name("apply")), _), args) if path.tpe.baseClasses.contains(seqFactorySym) =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
       // Array access
       case Apply(Select(path, Name("apply")), List(idx)) if isArray(path) =>
-        q"JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(idx)})"
+        q"org.jscala.JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(idx)})"
       // Array update
       case Apply(Select(path, Name("update")), List(key, value)) if isArray(path) =>
-        q"""JsBinOp("=", JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(key)}), ${jsExprOrDie(value)})"""
+        q"""org.jscala.JsBinOp("=", org.jscala.JsAccess(${jsExprOrDie(path)}, ${jsExprOrDie(key)}), ${jsExprOrDie(value)})"""
       // arrayOps
       case Apply(TypeApply(path, _), List(body)) if path.is("scala.Predef.refArrayOps") => jsArrayIdentOrExpr(body)
       case Apply(Select(Select(This(TypeName("scala")), Name("Predef")), Name(ops)), List(body)) if ops.endsWith("ArrayOps") => jsArrayIdentOrExpr(body)
@@ -191,7 +191,7 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
       // Tuples
       case Apply(TypeApply(Select(Select(Ident(Name("scala")), Name(tuple)), Name("apply")), _), args) if tuple.contains("Tuple") =>
         val params = listToExpr(args map jsExprOrDie)
-        q"JsArray($params)"
+        q"org.jscala.JsArray($params)"
     }
 
     lazy val jsGlobalFuncsExpr: ToExpr[JsExpr] = {
@@ -206,61 +206,61 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
       case Apply(Select(path, Name(n)), List(expr)) if path.is("org.jscala.package") && n.startsWith("implicit") =>
         jsExprOrDie(expr)
       case Apply(path, List(Literal(Constant(js: String)))) if path.is("org.jscala.package.include") =>
-        q"JsRaw($js)"
+        q"org.jscala.JsRaw($js)"
       case app@Apply(path, List(ident)) if path.is("org.jscala.package.include") =>
-        q"JsLazy(() => ${jsAst(ident)})"
+        q"org.jscala.JsLazy(() => ${jsAst(ident)})"
       case app@Apply(Apply(TypeApply(path, _), List(ident)), List(jss)) if path.is("org.jscala.package.inject") =>
         val call = c.Expr[JsExpr](Apply(jss, List(ident)))
-        q"JsLazy(() => $call)"
+        q"org.jscala.JsLazy(() => $call)"
       case Apply(Select(path, fn), args) if path.is("org.jscala.package") =>
         val params = funParams(args)
-        q"JsCall(JsIdent(${fn.decodedName.toString}), $params)"
+        q"org.jscala.JsCall(org.jscala.JsIdent(${fn.decodedName.toString}), $params)"
     }
 
     lazy val jsStringInterpolation: ToExpr[JsExpr] = {
       case q"scala.StringContext.apply(..$args).s(..$exprs)" =>
-        val at = args.map(a => q"JsString($a)")
+        val at = args.map(a => q"org.jscala.JsString($a)")
         val es = exprs.map(e => jsExprOrDie(e))
         val ls = es.zip(at.tail).flatMap { case (e, a) => List(e, a) }
-        val r = ls.foldLeft(at.head){case (r, a) => q"""JsBinOp("+", $r, $a)"""}
+        val r = ls.foldLeft(at.head){case (r, a) => q"""org.jscala.JsBinOp("+", $r, $a)"""}
         r
     }
 
 
     lazy val jsStringHelpersExpr: ToExpr[JsExpr] = {
       case q"$str.length()" if str.tpe.widen =:= typeOf[String] =>
-        q"""JsSelect(${jsExprOrDie(str)}, "length")"""
+        q"""org.jscala.JsSelect(${jsExprOrDie(str)}, "length")"""
     }
 
 
     lazy val jsNewExpr: ToExpr[JsExpr] = {
       case Apply(Select(New(Ident(ident)), _), args) =>
         val params = funParams(args)
-        q"JsNew(JsCall(JsIdent(${ident.decodedName.toString}), $params))"
+        q"org.jscala.JsNew(org.jscala.JsCall(org.jscala.JsIdent(${ident.decodedName.toString}), $params))"
       case Apply(Select(New(path), _), args) =>
         val params = funParams(args)
-        q"JsNew(JsCall(${jsExprOrDie(path)}, $params))"
+        q"org.jscala.JsNew(org.jscala.JsCall(${jsExprOrDie(path)}, $params))"
     }
 
     lazy val jsCallExpr: ToExpr[JsExpr] = {
       case Apply(Select(lhs, name), List(rhs)) if name.decodedName.toString.endsWith("_=") =>
-        q"""JsBinOp("=", JsSelect(${jsExprOrDie(lhs)}, ${name.decodedName.toString.dropRight(2)}), ${jsExprOrDie(rhs)})"""
+        q"""org.jscala.JsBinOp("=", org.jscala.JsSelect(${jsExprOrDie(lhs)}, ${name.decodedName.toString.dropRight(2)}), ${jsExprOrDie(rhs)})"""
       case Apply(Apply(Select(sel, Name("applyDynamic")), List(Literal(Constant(name: String)))), args) =>
-        val callee = q"JsSelect(${jsExprOrDie(sel)}, $name)"
+        val callee = q"org.jscala.JsSelect(${jsExprOrDie(sel)}, $name)"
         val params = listToExpr(args.map(jsExprOrDie))
-        q"JsCall($callee, $params)"
+        q"org.jscala.JsCall($callee, $params)"
       case Apply(Apply(Select(sel, Name("updateDynamic")), List(Literal(Constant(name: String)))), List(arg)) =>
-        val callee = q"JsSelect(${jsExprOrDie(sel)}, $name)"
-        q"""JsBinOp("=", $callee, ${jsExprOrDie(arg)})"""
+        val callee = q"org.jscala.JsSelect(${jsExprOrDie(sel)}, $name)"
+        q"""org.jscala.JsBinOp("=", $callee, ${jsExprOrDie(arg)})"""
       case Apply(Select(sel, Name("selectDynamic")), List(Literal(Constant(name: String)))) =>
-        q"JsSelect(${jsExprOrDie(sel)}, $name)"
+        q"org.jscala.JsSelect(${jsExprOrDie(sel)}, $name)"
       case app@Apply(fun, args) if app.tpe <:< typeOf[JsAst] =>
         val expr = c.Expr[JsAst](app)
-        q"JsLazy(() => $expr)"
+        q"org.jscala.JsLazy(() => $expr)"
       case Apply(fun, args) =>
         val callee = jsExprOrDie apply fun
         val params = funParams(args)
-        q"JsCall($callee, $params)"
+        q"org.jscala.JsCall($callee, $params)"
     }
 
     lazy val jsIfStmt: ToExpr[JsIf] = {
@@ -268,7 +268,7 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val condJsExpr = jsExprOrDie(cond)
         val thenJsExpr = jsStmtOrDie(thenp)
         val elseJsStmt = if (isUnit(elsep)) q"None" else q"Some(${jsStmtOrDie(elsep)})"
-        q"JsIf($condJsExpr, $thenJsExpr, $elseJsStmt)"
+        q"org.jscala.JsIf($condJsExpr, $thenJsExpr, $elseJsStmt)"
     }
 
     lazy val jsTernaryExpr: ToExpr[JsTernary] = {
@@ -276,14 +276,14 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val condJsExpr = jsExprOrDie(cond)
         val thenJsExpr = jsExprOrDie(thenp)
         val elseExpr = jsExprOrDie(elsep)
-        q"JsTernary($condJsExpr, $thenJsExpr, $elseExpr)"
+        q"org.jscala.JsTernary($condJsExpr, $thenJsExpr, $elseExpr)"
     }
 
     lazy val jsWhileStmt: ToExpr[JsWhile] = {
       case LabelDef(termName, Nil, If(cond, Block(List(body), _), _)) if termName.encoded.startsWith("while$") =>
         val condJsExpr = jsExprOrDie(cond)
         val bodyJsStmt = jsStmtOrDie(body)
-        q"JsWhile($condJsExpr, $bodyJsStmt)"
+        q"org.jscala.JsWhile($condJsExpr, $bodyJsStmt)"
     }
 
     def addAssign(tree: Tree, name: Name) = tree match {
@@ -296,7 +296,7 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val condJsExpr = jsExprOrDie(cond)
         val thenJsExpr = jsStmtOrDie(addAssign(thenp, name))
         val elseJsExpr = jsStmtOrDie(addAssign(elsep, name))
-        q"JsIf($condJsExpr, $thenJsExpr, Some($elseJsExpr))"
+        q"org.jscala.JsIf($condJsExpr, $thenJsExpr, Some($elseJsExpr))"
     }
 
     lazy val jsMatchExpr: PartialFunction[(Name, Tree), Tree] = {
@@ -308,16 +308,16 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val identifier = name.decodedName.toString
         if (jsTernaryExpr.isDefinedAt(rhs)) {
           val idents = listToExpr(List(q"$identifier -> ${jsTernaryExpr(rhs)}"))
-          q"JsVarDef($idents)"
+          q"org.jscala.JsVarDef($idents)"
         } else {
           val funcs = Seq(jsIfExpr, jsMatchExpr).reduceLeft(_ orElse _) andThen { expr =>
-            val ident = listToExpr(List(q"$identifier -> JsUnit"))
-            q"JsStmts(List(JsVarDef($ident), $expr))"
+            val ident = listToExpr(List(q"$identifier -> org.jscala.JsUnit"))
+            q"org.jscala.JsStmts(List(org.jscala.JsVarDef($ident), $expr))"
           }
           val x = name -> rhs
           funcs.applyOrElse(x, (t: (TermName, Tree)) => {
             val ident = listToExpr(List(q"$identifier -> ${jsExprOrDie(rhs)}"))
-            q"JsVarDef($ident)"
+            q"org.jscala.JsVarDef($ident)"
           })
         }
 
@@ -326,16 +326,16 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
     lazy val jsFunBody: ToExpr[JsBlock] = {
       case lit@Literal(_) =>
         val body = if (isUnit(lit)) Nil else List(jsReturnStmt(lit))
-        q"JsBlock(${listToExpr(body)})"
+        q"org.jscala.JsBlock(${listToExpr(body)})"
       case b@Block(stmts, expr) =>
         val lastExpr = if (isUnit(expr)) Nil
         else if (expr.tpe =:= typeOf[Unit]) List(jsStmtOrDie(expr))
         else List(jsReturn(expr))
         val ss = listToExpr(stmts.map(jsStmtOrDie) ::: lastExpr)
-        q"JsBlock($ss)"
+        q"org.jscala.JsBlock($ss)"
       case rhs =>
-        if (rhs.tpe =:= typeOf[Unit]) q"JsBlock(List(${jsStmtOrDie(rhs)}))"
-        else q"JsBlock(List(${jsReturn(rhs)}))"
+        if (rhs.tpe =:= typeOf[Unit]) q"org.jscala.JsBlock(List(${jsStmtOrDie(rhs)}))"
+        else q"org.jscala.JsBlock(List(${jsReturn(rhs)}))"
     }
 
     lazy val jsFunDecl: ToExpr[JsFunDecl] = {
@@ -344,18 +344,18 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val a = vparamss.headOption.map(vp => vp.map(v => q"${v.name.decodedName.toString}")).getOrElse(Nil)
         val params = listToExpr(a)
         val body = jsFunBody(rhs)
-        q"JsFunDecl($ident, $params, $body)"
+        q"org.jscala.JsFunDecl($ident, $params, $body)"
     }
 
     lazy val jsAnonFunDecl: ToExpr[JsAnonFunDecl] = {
       case Block(Nil, Function(vparams, rhs)) =>
         val params = listToExpr(vparams.map(v => q"${v.name.decodedName.toString}"))
         val body = jsFunBody(rhs)
-        q"JsAnonFunDecl($params, $body)"
+        q"org.jscala.JsAnonFunDecl($params, $body)"
       case Function(vparams, rhs) =>
         val params = listToExpr(vparams.map(v => q"${v.name.decodedName.toString}"))
         val body = jsFunBody(rhs)
-        q"JsAnonFunDecl($params, $body)"
+        q"org.jscala.JsAnonFunDecl($params, $body)"
     }
 
     lazy val jsTry: ToExpr[JsTry] = {
@@ -363,32 +363,32 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
         val ctch = catchBlock match {
           case Nil => q"None"
           case List(CaseDef(Bind(pat, _), EmptyTree, catchBody)) =>
-            q"Some(JsCatch(JsIdent(${pat.decodedName.toString}), ${jsStmtOrDie(catchBody)}))"
+            q"Some(org.jscala.JsCatch(org.jscala.JsIdent(${pat.decodedName.toString}), ${jsStmtOrDie(catchBody)}))"
         }
         val fin = if (finBody.equalsStructure(EmptyTree)) q"None"
         else q"Some(${jsStmtOrDie(finBody)})"
-        q"JsTry(${jsStmtOrDie(body)}, $ctch, $fin)"
+        q"org.jscala.JsTry(${jsStmtOrDie(body)}, $ctch, $fin)"
     }
 
     lazy val jsThrowExpr: ToExpr[JsThrow] = {
-      case Throw(expr) => q"JsThrow(${jsExprOrDie(expr)})"
+      case Throw(expr) => q"org.jscala.JsThrow(${jsExprOrDie(expr)})"
     }
 
     def jsSwitchGen(expr: Tree, cases: List[CaseDef], f: Tree => Tree) = {
       val cs = cases collect {
-        case CaseDef(const@Literal(Constant(_)), EmptyTree, body) => q"JsCase(List(${jsLit(const)}), ${jsStmtOrDie(f(body))})"
+        case CaseDef(const@Literal(Constant(_)), EmptyTree, body) => q"org.jscala.JsCase(List(${jsLit(const)}), ${jsStmtOrDie(f(body))})"
         case CaseDef(sel@Select(path, n), EmptyTree, body) =>
-          q"JsCase(List(${jsExprOrDie(sel)}), ${jsStmtOrDie(f(body))})"
+          q"org.jscala.JsCase(List(${jsExprOrDie(sel)}), ${jsStmtOrDie(f(body))})"
         case CaseDef(Alternative(xs), EmptyTree, body) =>
           val stmt = jsStmtOrDie(f(body))
           val consts = listToExpr(xs map(c => jsLit(c)))
-          q"JsCase($consts, $stmt)"
+          q"org.jscala.JsCase($consts, $stmt)"
       }
       val df = (cases collect {
-        case CaseDef(Ident(nme.WILDCARD), EmptyTree, body) => q"Some(JsDefault(${jsStmtOrDie(f(body))}))"
+        case CaseDef(Ident(nme.WILDCARD), EmptyTree, body) => q"Some(org.jscala.JsDefault(${jsStmtOrDie(f(body))}))"
       }).headOption.getOrElse(q"None")
       val css = listToExpr(cs)
-      q"JsSwitch(${jsExprOrDie(expr)}, $css, $df)"
+      q"org.jscala.JsSwitch(${jsExprOrDie(expr)}, $css, $df)"
     }
 
     lazy val jsSwitch: ToExpr[JsSwitch] = {
@@ -410,7 +410,7 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
       case cd@ClassDef(mods, clsName, _, Template(_, _, body)) if mods.hasFlag(Flag.TRAIT) =>
         // Remember trait AST to embed its definitions in concrete class for simplicity
         traits(cd.symbol.fullName) = body
-        q"JsUnit"
+        q"org.jscala.JsUnit"
       case cd@ClassDef(_, clsName, _, t@Template(base, _, body)) =>
         val ctor = body.collect {
           case f@DefDef(mods, n, _, argss, _, Block(stats, _)) if n == nme.CONSTRUCTOR =>
@@ -418,7 +418,7 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
             a
         }
         if (ctor.size != 1) c.abort(c.enclosingPosition, "Only single primary constructor is currently supported. Sorry.")
-        val init = ctor.head.map(f => f -> q"JsIdent($f)")
+        val init = ctor.head.map(f => f -> q"org.jscala.JsIdent($f)")
         val inherited = t.tpe.baseClasses.map(_.fullName).flatMap {bc => traits.get(bc).toList }
         val bigBody = inherited.foldRight(List[Tree]())(_ ::: _) ::: body
         val defs = bigBody.collect(objectFields)
@@ -430,28 +430,28 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
           case _: DefDef => None
           case stmt => Some(stmt)
         }.flatten.map(jsStmtOrDie))
-        val ctorFuncDecl = q"JsFunDecl(${clsName.decodedName.toString}, $args, JsBlock($ctorBody))"
-        q"JsObjDecl(${clsName.decodedName.toString}, $ctorFuncDecl, $fs)"
+        val ctorFuncDecl = q"org.jscala.JsFunDecl(${clsName.decodedName.toString}, $args, org.jscala.JsBlock($ctorBody))"
+        q"org.jscala.JsObjDecl(${clsName.decodedName.toString}, $ctorFuncDecl, $fs)"
     }
 
     lazy val jsAnonObjDecl: ToExpr[JsAnonObjDecl] = {
       case Block(List(ClassDef(_, clsName, _, Template(_, _, body))), _/* Constructor call */) =>
         val defs = body.collect(objectFields)
         val params = listToExpr(defs.map { case (n, v) => q"($n, $v)" })
-        q"JsAnonObjDecl($params)"
+        q"org.jscala.JsAnonObjDecl($params)"
     }
 
     lazy val jsReturn1: ToExpr[JsStmt] = {
-      case Return(expr) => q"JsReturn(${jsExprOrDie(expr)})"
+      case Return(expr) => q"org.jscala.JsReturn(${jsExprOrDie(expr)})"
     }
     lazy val jsReturn: ToExpr[JsStmt] = jsReturnStmt orElse jsStmtOrDie
-    lazy val jsReturnStmt: ToExpr[JsReturn] = jsExpr andThen (jsExpr => q"JsReturn($jsExpr)")
+    lazy val jsReturnStmt: ToExpr[JsReturn] = jsExpr andThen (jsExpr => q"org.jscala.JsReturn($jsExpr)")
 
     lazy val jsBlock: ToExpr[JsBlock] = {
       case Block(stmts, expr) =>
         val stmtTrees = if (expr.equalsStructure(q"()")) stmts else stmts :+ expr
         val ss = listToExpr(stmtTrees map jsStmtOrDie)
-        q"JsBlock($ss)"
+        q"org.jscala.JsBlock($ss)"
     }
 
     def die(msg: String) = new ToExpr[Nothing] {
@@ -508,7 +508,7 @@ class ScalaToJsConverter[C <: Context](val c: C, debug: Boolean) extends JsBasis
     val expr = jsAst apply tree
 
     val resultTree = if (!tree.tpe.=:=(typeOf[Nothing]) && functionTypes.exists(tree.tpe.<:<)) {
-      q"${expr}.asInstanceOf[JsAst with ${tree.tpe}]"
+      q"${expr}.asInstanceOf[org.jscala.JsAst with ${tree.tpe}]"
     } else expr
 
     resultTree


### PR DESCRIPTION
...d classes with same name.

Closes #27
